### PR TITLE
Add indent pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+out
+node_modules

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+// A launch configuration that launches the extension inside a new window
+{
+    "version": "0.1.0",
+    "configurations": [
+        {
+            "name": "Launch Extension",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
+            "sourceMaps": true,
+            "outFiles": [ "${workspaceRoot}/out/src/**/*.js" ],
+            "preLaunchTask": "npm"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,9 @@
+{
+	"version": "0.1.0",
+	"command": "npm",
+	"isShellCommand": true,
+	"showOutput": "silent",
+	"args": ["run", "compile", "--loglevel", "silent"],
+    "isWatching": true,
+	"problemMatcher": "$tsc-watch"
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
 	"engines": {
 		"vscode": "0.10.x"
 	},
+	"activationEvents": ["onLanguage:latex"],
+	"main": "./out/src/latexMain",
 	"contributes": {
 		"languages": [
 			{
@@ -63,5 +65,17 @@
 				"path": "./syntaxes/tex.tmLanguage"
 			}
 		]
-	}
+	},
+    "scripts": {
+        "vscode:prepublish": "tsc -p ./",
+        "compile": "tsc -watch -p ./",
+        "postinstall": "node ./node_modules/vscode/bin/install"
+    },
+	"devDependencies": {
+        "typescript": "^2.0.3",
+        "vscode": "^1.0.0",
+        "mocha": "^2.3.3",
+        "@types/node": "^6.0.40",
+        "@types/mocha": "^2.2.32"
+    }
 }

--- a/src/latexMain.ts
+++ b/src/latexMain.ts
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+import { ExtensionContext, languages } from 'vscode';
+
+export function activate(context: ExtensionContext): any {
+	languages.setLanguageConfiguration('latex', {
+		indentationRules: {
+			increaseIndentPattern: /^\s*\\begin\{.*\}/,
+			decreaseIndentPattern: /^\s*\\end(\{.*\})?$/
+		},
+		wordPattern: /(-?\d+(?:\.\d+))|(:?[A-Za-z][^-`~@#%^&()=+[{}|;:'",<>/.*\]\s\\!?]*[!?]?)/
+	});
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "outDir": "./out",
+        "lib": [
+            "es6"
+        ],
+        "sourceMap": true,
+        "rootDir": "."
+    },
+    "exclude": [
+        "node_modules",
+        ".vscode-test"
+    ]
+}


### PR DESCRIPTION
Added indent for `begin` and `end`.
latexMain.ts(https://github.com/Ikuyadeu/vscode-LaTeX/blob/add_indent/src/latexMain.ts)'s regex is based
[tmBunble for LaTeX](https://github.com/textmate/latex.tmbundle/blob/master/Preferences/Indendation.tmPreferences).